### PR TITLE
Update dependencies and make outwatch compile with purs 0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 
 node_js:
   - "6"
-  - "5"
 
 before_install:
   - npm install -g pulp bower purescript

--- a/bower.json
+++ b/bower.json
@@ -9,18 +9,18 @@
     "output"
   ],
   "dependencies": {
-    "purescript-prelude": "^2.1.0",
-    "purescript-console": "^2.0.0",
-    "purescript-snabbdom": "^0.2.0",
-    "purescript-foldable-traversable": "^2.0.0",
-    "purescript-affjax": "^3.0.2",
-    "purescript-rxjs": "https://github.com/LukaJCB/purescript-rxjs.git"
+    "purescript-prelude": "^3.0.0",
+    "purescript-console": "^3.0.0",
+    "purescript-snabbdom": "https://github.com/sloosch/purescript-snabbdom.git#purs0.11",
+    "purescript-foldable-traversable": "^3.0.0",
+    "purescript-affjax": "^4.0.0",
+    "purescript-rxjs": "https://github.com/sloosch/purescript-rxjs.git#purs0.11"
   },
   "devDependencies": {
-    "purescript-psci-support": "^2.0.0",
-    "purescript-test-unit": "^10.1.0",
-    "purescript-quickcheck": "^3.1.1",
-    "purescript-refs": "^2.0.0"
+    "purescript-psci-support": "^3.0.0",
+    "purescript-test-unit": "^11.0.0",
+    "purescript-quickcheck": "^4.0.0",
+    "purescript-refs": "^3.0.0"
   },
   "repository": {
       "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "devDependencies": {
     "bower": "^1.8.0",
     "phantomjs": "^2.1.7",
-    "pulp": "^10.0.1",
-    "purescript": "^0.10.7",
+    "pulp": "^11.0.0",
+    "purescript": "^0.11.3",
     "rimraf": "^2.6.1"
   },
   "scripts": {

--- a/src/OutWatch/Helpers/Promise.purs
+++ b/src/OutWatch/Helpers/Promise.purs
@@ -1,10 +1,10 @@
 module OutWatch.Helpers.Promise where
 
 import Prelude
-import Control.Monad.Eff (Eff)
+import Control.Monad.Eff (Eff, kind Effect)
 
 
-foreign import data Promise :: # ! -> * -> *
+foreign import data Promise :: # Effect -> Type -> Type
 
 
 foreign import success :: forall e a. Promise e a -> a -> Eff e Unit

--- a/test/DomEventSpec.purs
+++ b/test/DomEventSpec.purs
@@ -1,7 +1,6 @@
 module Test.DomEventSpec where
 
 import Control.Monad.Aff.AVar (AVAR)
-import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Exception (EXCEPTION)
@@ -9,24 +8,19 @@ import Control.Monad.Eff.Random (RANDOM)
 import Control.Monad.Eff.Ref (REF, modifyRef, newRef, readRef)
 import DOM (DOM)
 import DOM.Event.EventTarget (dispatchEvent)
-import DOM.HTML (window)
-import DOM.HTML.Document (body)
-import DOM.HTML.Types (htmlDocumentToDocument, htmlElementToNode)
-import DOM.HTML.Window (document)
-import DOM.Node.Document (createElement)
-import DOM.Node.Element (setAttribute)
-import DOM.Node.Node (appendChild, setTextContent, textContent)
-import DOM.Node.ParentNode (childElementCount, querySelector)
-import DOM.Node.Types (Document, Node, documentToParentNode, elementToEventTarget, elementToNode)
+import DOM.Node.Node (textContent)
+import DOM.Node.ParentNode (childElementCount)
+import DOM.Node.Types (elementToEventTarget)
 import Data.Array (length) as Array
 import OutWatch.Attributes (childShow, children, click, text, (<==), (==>))
 import OutWatch.Core (render)
 import OutWatch.Dom.EmitterBuilder (mapE, override)
 import OutWatch.Sink (create)
 import OutWatch.Tags (div, span)
-import Prelude (Unit, bind, const, map, not, pure, show, (#), ($), (==))
+import Prelude (bind, const, discard, map, not, show, (#), ($), (==))
 import RxJS.Observable (fromArray, just)
 import Snabbdom (VDOM)
+import Test.Helper (afterAll, createDomRoot, unsafeFindElement)
 import Test.JsHelpers (newEvent)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert (assert)
@@ -40,31 +34,29 @@ domEventSuite :: forall e. TestSuite (console :: CONSOLE, testOutput :: TESTOUTP
 domEventSuite =
   suite "Dom Event Suite" do
     test "The DOM Events Api should be able to update the DOM correctly" do
-      liftEff createDomRoot
+      createDomRoot
       let msg1 = "HelloWorld!"
           msg2 = "Another Message!"
           childNodes = fromArray [ msg1, msg2 ]
           root = span [ childShow <== childNodes ]
       liftEff (render "#app" root)
-      doc <- liftEff getDocument
-      elem <- liftEff (querySelector "span" (documentToParentNode doc))
+      elem <- unsafeFindElement "span"
       val <- liftEff (textContent (unsafeCoerce elem))
       assert "Should be equal" $ val == show msg2
-      liftEff (afterAll)
+      afterAll
     test "The DOM Events Api should be able to set the children of a DOM element" do
-      liftEff createDomRoot
+      createDomRoot
       let arr = [1,2,3,4,5,6,7,8,5,4] # map (\n -> div [text $ show n])
           childValues = just arr
           root = span [ children <== childValues ]
       liftEff (render "#app" root)
-      doc <- liftEff getDocument
-      elem <- liftEff (querySelector "span" (documentToParentNode doc))
+      elem <- unsafeFindElement "span"
       numberOfChildren <- liftEff (childElementCount (unsafeCoerce elem))
       assert "Should be equal" $ numberOfChildren == (Array.length arr)
-      liftEff (afterAll)
+      afterAll
     test "The DOM Events Api should be able to emit events to a Sink" do
       refFlag <- liftEff (newRef false)
-      liftEff createDomRoot
+      createDomRoot
       let sink = create (\_ -> modifyRef refFlag (\_ -> true))
           root = div [ click ==> sink ]
       flagBeforeAll <- liftEff (readRef refFlag)
@@ -72,81 +64,54 @@ domEventSuite =
       liftEff (render "#app" root)
       flagAfterRendering <- liftEff (readRef refFlag)
       assert "Emitter shouldn't emit after initial render" (not flagAfterRendering)
-      doc <- liftEff getDocument
-      elem <- liftEff (querySelector "div" (documentToParentNode doc))
+      elem <- unsafeFindElement "div"
       let ev = newEvent "click"
           evTarget = elementToEventTarget $ unsafeCoerce elem
-      liftEff (dispatchEvent ev evTarget)
+      _ <- liftEff (dispatchEvent ev evTarget)
       flagAfterClick <- liftEff (readRef refFlag)
       assert "Sink should've been called after click" (flagAfterClick)
-      liftEff (afterAll)
+      afterAll
     test "The DOM Events Api should be able to handle two events of the same type" do
       refFlag <- liftEff (newRef false)
       refFlag2 <- liftEff (newRef false)
-      liftEff createDomRoot
+      createDomRoot
       let sink = create (\_ -> modifyRef refFlag (\_ -> true))
           sink2 = create (\_ -> modifyRef refFlag2 (\_ -> true))
           root = div [ click ==> sink , click ==> sink2 ]
       liftEff (render "#app" root)
-      doc <- liftEff getDocument
-      elem <- liftEff (querySelector "div" (documentToParentNode doc))
+      elem <- unsafeFindElement "div"
       let ev = newEvent "click"
           evTarget = elementToEventTarget $ unsafeCoerce elem
-      liftEff (dispatchEvent ev evTarget)
+      _ <- liftEff (dispatchEvent ev evTarget)
       flagAfterClick <- liftEff (readRef refFlag)
       flagAfterClick2 <- liftEff (readRef refFlag2)
       assert "Sink should've been called after click" (flagAfterClick)
       assert "Second Sink should've been called after click" (flagAfterClick2)
-      liftEff (afterAll)
+      afterAll
     test "Event emitters should be able to have their values mapped" do
       refFlag <- liftEff (newRef false)
-      liftEff createDomRoot
+      createDomRoot
       let sink = create (\b -> modifyRef refFlag (\_ -> b))
           root = div [ mapE click (const true) ==> sink ]
       liftEff (render "#app" root)
-      doc <- liftEff getDocument
-      elem <- liftEff (querySelector "div" (documentToParentNode doc))
+      elem <- unsafeFindElement "div"
       let ev = newEvent "click"
           evTarget = elementToEventTarget $ unsafeCoerce elem
-      liftEff (dispatchEvent ev evTarget)
+      _ <- liftEff (dispatchEvent ev evTarget)
       flagAfterClick <- liftEff (readRef refFlag)
       assert "Sink should be called on click" (flagAfterClick)
-      liftEff (afterAll)
+      afterAll
     test "Event emitters should be able to have their values overriden by another Observable" do
       refFlag <- liftEff (newRef false)
-      liftEff createDomRoot
+      createDomRoot
       let sink = create (\b -> modifyRef refFlag (\_ -> b))
           stream = just true
           root = div [ override click stream ==> sink ]
       liftEff (render "#app" root)
-      doc <- liftEff getDocument
-      elem <- liftEff (querySelector "div" (documentToParentNode doc))
+      elem <- unsafeFindElement "div"
       let ev = newEvent "click"
           evTarget = elementToEventTarget $ unsafeCoerce elem
-      liftEff (dispatchEvent ev evTarget)
+      _ <- liftEff (dispatchEvent ev evTarget)
       flagAfterClick <- liftEff (readRef refFlag)
       assert "Sink should be called on click" (flagAfterClick)
-      liftEff (afterAll)
-
-getDocument :: forall e. Eff (dom :: DOM | e) Document
-getDocument = do
-  wndow <- window
-  doc <- document wndow
-  pure $ htmlDocumentToDocument doc
-
-createDomRoot :: forall e. Eff (dom :: DOM | e) Node
-createDomRoot = do
-  doc <- getDocument
-  node <- createElement "div" doc
-  bdy <- body $ unsafeCoerce doc
-  child <- appendChild (elementToNode node) (htmlElementToNode (unsafeCoerce bdy))
-  setAttribute "id" "app" (unsafeCoerce child)
-  pure child
-
-afterAll :: forall e. Eff (dom :: DOM | e) Unit
-afterAll = do
-  wndow <- window
-  doc <- document wndow
-  node <- createElement "div" (htmlDocumentToDocument doc)
-  bdy <- body doc
-  setTextContent "" (unsafeCoerce bdy)
+      afterAll

--- a/test/Helper.purs
+++ b/test/Helper.purs
@@ -16,7 +16,7 @@ import DOM.Node.ParentNode (QuerySelector(QuerySelector), querySelector)
 import DOM.Node.Types (Document, Element, documentToParentNode, elementToNode)
 import Data.Maybe (Maybe(Just, Nothing))
 import Partial.Unsafe (unsafeCrashWith)
-import Prelude (Unit, bind, pure, ($), (<>))
+import Prelude (Unit, bind, pure, ($), (<#>), (<>), (>>=))
 import Unsafe.Coerce (unsafeCoerce)
 
 
@@ -29,10 +29,7 @@ unsafeFindElement queryStr = liftEff do
     Just elem -> pure elem
 
 getDocument :: forall e m. (MonadEff (dom :: DOM | e) m) => m Document
-getDocument = liftEff do
-  wndow <- window
-  doc <- document wndow
-  pure $ htmlDocumentToDocument doc
+getDocument = liftEff $ window >>= document <#> htmlDocumentToDocument
 
 createDomRoot :: forall e m. (MonadEff (dom :: DOM | e) m) => m Unit
 createDomRoot = liftEff do

--- a/test/Helper.purs
+++ b/test/Helper.purs
@@ -16,7 +16,7 @@ import DOM.Node.ParentNode (QuerySelector(QuerySelector), querySelector)
 import DOM.Node.Types (Document, Element, documentToParentNode, elementToNode)
 import Data.Maybe (Maybe(Just, Nothing))
 import Partial.Unsafe (unsafeCrashWith)
-import Prelude (Unit, bind, discard, pure, unit, ($), (<>))
+import Prelude (Unit, bind, pure, ($), (<>))
 import Unsafe.Coerce (unsafeCoerce)
 
 
@@ -41,7 +41,6 @@ createDomRoot = liftEff do
   node <- createElement "div" doc
   child <- appendChild (elementToNode node) (elementToNode bdy)
   setAttribute "id" "app" (unsafeCoerce child)
-  pure unit
 
 afterAll :: forall e m. (MonadEff (dom :: DOM | e) m) => m Unit
 afterAll = liftEff do

--- a/test/Helper.purs
+++ b/test/Helper.purs
@@ -33,15 +33,13 @@ getDocument = liftEff $ window >>= document <#> htmlDocumentToDocument
 
 createDomRoot :: forall e m. (MonadEff (dom :: DOM | e) m) => m Unit
 createDomRoot = liftEff do
-  doc <- getDocument
   bdy <- unsafeFindElement "body"
-  node <- createElement "div" doc
+  node <- getDocument >>= createElement "div"
   child <- appendChild (elementToNode node) (elementToNode bdy)
   setAttribute "id" "app" (unsafeCoerce child)
 
 afterAll :: forall e m. (MonadEff (dom :: DOM | e) m) => m Unit
 afterAll = liftEff do
-  doc <- getDocument
-  node <- createElement "div" doc
+  node <- getDocument >>= createElement "div"
   bdy <- unsafeFindElement "body"
   setTextContent "" (unsafeCoerce bdy)

--- a/test/Helper.purs
+++ b/test/Helper.purs
@@ -28,7 +28,7 @@ unsafeFindElement queryStr = liftEff do
     Nothing -> unsafeCrashWith $ "Element for query '" <> queryStr <> "' was not found."
     Just elem -> pure elem
 
-getDocument ::  forall e m. (MonadEff (dom :: DOM | e) m) => m Document
+getDocument :: forall e m. (MonadEff (dom :: DOM | e) m) => m Document
 getDocument = liftEff do
   wndow <- window
   doc <- document wndow

--- a/test/Helper.purs
+++ b/test/Helper.purs
@@ -1,0 +1,51 @@
+module Test.Helper (
+    unsafeFindElement
+  , createDomRoot
+  , afterAll
+  ) where
+
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import DOM (DOM)
+import DOM.HTML (window)
+import DOM.HTML.Types (htmlDocumentToDocument)
+import DOM.HTML.Window (document)
+import DOM.Node.Document (createElement)
+import DOM.Node.Element (setAttribute)
+import DOM.Node.Node (appendChild, setTextContent)
+import DOM.Node.ParentNode (QuerySelector(QuerySelector), querySelector)
+import DOM.Node.Types (Document, Element, documentToParentNode, elementToNode)
+import Data.Maybe (Maybe(Just, Nothing))
+import Partial.Unsafe (unsafeCrashWith)
+import Prelude (Unit, bind, discard, pure, unit, ($), (<>))
+import Unsafe.Coerce (unsafeCoerce)
+
+
+unsafeFindElement :: forall e m. (MonadEff (dom :: DOM | e) m) => String -> m Element
+unsafeFindElement queryStr = liftEff do
+  doc <- getDocument
+  maybeElem <- querySelector (QuerySelector queryStr) (documentToParentNode doc)
+  case maybeElem of
+    Nothing -> unsafeCrashWith $ "Element for query '" <> queryStr <> "' was not found."
+    Just elem -> pure elem
+
+getDocument ::  forall e m. (MonadEff (dom :: DOM | e) m) => m Document
+getDocument = liftEff do
+  wndow <- window
+  doc <- document wndow
+  pure $ htmlDocumentToDocument doc
+
+createDomRoot :: forall e m. (MonadEff (dom :: DOM | e) m) => m Unit
+createDomRoot = liftEff do
+  doc <- getDocument
+  bdy <- unsafeFindElement "body"
+  node <- createElement "div" doc
+  child <- appendChild (elementToNode node) (elementToNode bdy)
+  setAttribute "id" "app" (unsafeCoerce child)
+  pure unit
+
+afterAll :: forall e m. (MonadEff (dom :: DOM | e) m) => m Unit
+afterAll = liftEff do
+  doc <- getDocument
+  node <- createElement "div" doc
+  bdy <- unsafeFindElement "body"
+  setTextContent "" (unsafeCoerce bdy)

--- a/test/LifecycleHookSpec.purs
+++ b/test/LifecycleHookSpec.purs
@@ -1,32 +1,21 @@
 module Test.LifecycleHookSpec where
 
-import Control.Applicative (pure)
 import Control.Monad.Aff.AVar (AVAR)
-import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Random (RANDOM)
 import Control.Monad.Eff.Ref (REF, modifyRef, newRef, readRef)
 import DOM (DOM)
-import DOM.HTML (window)
-import DOM.HTML.Document (body)
-import DOM.HTML.Types (htmlDocumentToDocument, htmlElementToNode)
-import DOM.HTML.Window (document)
-import DOM.Node.Document (createElement)
-import DOM.Node.Element (setAttribute)
-import DOM.Node.Node (appendChild, setTextContent)
-import DOM.Node.Types (Node, elementToNode)
-import Data.Unit (Unit)
 import OutWatch.Attributes (child, destroy, insert, text, update, (<==), (==>))
 import OutWatch.Core (VDOM, render)
 import OutWatch.Sink (create)
 import OutWatch.Tags (div, h3, span)
-import Prelude (bind, not)
+import Prelude (bind, discard, not)
 import RxJS.Observable (fromArray)
+import Test.Helper (afterAll, createDomRoot)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert (assert)
 import Test.Unit.Console (TESTOUTPUT)
-import Unsafe.Coerce (unsafeCoerce)
 
 
 
@@ -36,7 +25,7 @@ lifecycleHookSuite =
   suite "lifecycle hook suite" do
     test "insertion hooks should be called when a VNode is inserted" do
       refFlag <- liftEff (newRef false)
-      liftEff createDomRoot
+      createDomRoot
       let sink = create (\_ -> modifyRef refFlag (\_ -> true))
           root = div [ insert ==> sink ]
       flagBeforeRendering <- liftEff (readRef refFlag)
@@ -44,10 +33,10 @@ lifecycleHookSuite =
       liftEff (render "#app" root)
       flagAfterRendering <- liftEff (readRef refFlag)
       assert "Insert hook should have been called after rendering" (flagAfterRendering)
-      liftEff (afterAll)
+      afterAll
     test "destruction hooks should be called when a VNode is destroyed" do
       refFlag <- liftEff (newRef false)
-      liftEff createDomRoot
+      createDomRoot
       let sink = create (\_ -> modifyRef refFlag (\_ -> true))
           innerChild = fromArray [ span [ destroy ==> sink ], h3 [] ]
           root = div [ child <== innerChild ]
@@ -56,10 +45,10 @@ lifecycleHookSuite =
       liftEff (render "#app" root)
       flagAfterRendering <- liftEff (readRef refFlag)
       assert "Destroy hook should have been called after rendering" (flagAfterRendering)
-      liftEff (afterAll)
+      afterAll
     test "update hooks should be called when a VNode is updated" do
       refFlag <- liftEff (newRef false)
-      liftEff createDomRoot
+      createDomRoot
       let sink = create (\_ -> modifyRef refFlag (\_ -> true))
           innerChild = fromArray [ span [ update ==> sink, text "First" ], span [ update ==> sink , text "second" ] ]
           root = div [ child <== innerChild ]
@@ -68,22 +57,4 @@ lifecycleHookSuite =
       liftEff (render "#app" root)
       flagAfterRendering <- liftEff (readRef refFlag)
       assert "Update hook should have been called after rendering" (flagAfterRendering)
-      liftEff (afterAll)
-
-createDomRoot :: forall e. Eff (dom :: DOM | e) Node
-createDomRoot = do
-  wndow <- window
-  doc <- document wndow
-  node <- createElement "div" (htmlDocumentToDocument doc)
-  bdy <- body doc
-  child <- appendChild (elementToNode node) (htmlElementToNode (unsafeCoerce bdy))
-  setAttribute "id" "app" (unsafeCoerce child)
-  pure child
-
-afterAll :: forall e. Eff (dom :: DOM | e) Unit
-afterAll = do
-  wndow <- window
-  doc <- document wndow
-  node <- createElement "div" (htmlDocumentToDocument doc)
-  bdy <- body doc
-  setTextContent "" (unsafeCoerce bdy)
+      afterAll

--- a/test/OutWatchDomSpec.purs
+++ b/test/OutWatchDomSpec.purs
@@ -1,21 +1,12 @@
 module Test.OutWatchDomSpec where
 
 import Control.Monad.Aff.AVar (AVAR)
-import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Random (RANDOM)
 import DOM (DOM)
-import DOM.HTML (window)
-import DOM.HTML.Document (body)
 import DOM.HTML.HTMLInputElement (value) as HTML
-import DOM.HTML.Types (htmlDocumentToDocument, htmlElementToNode)
-import DOM.HTML.Window (document)
-import DOM.Node.Document (createElement)
-import DOM.Node.Element (setAttribute)
-import DOM.Node.Node (appendChild, setTextContent, textContent)
-import DOM.Node.ParentNode (querySelector)
-import DOM.Node.Types (Document, Node, documentToParentNode, elementToNode)
+import DOM.Node.Node (textContent)
 import Data.String (length)
 import OutWatch.Attributes (className, id, text, value, (:=), (<==))
 import OutWatch.Core (render)
@@ -23,9 +14,10 @@ import OutWatch.Dom.Builder (toEmptyIfFalse)
 import OutWatch.Dom.DomUtils (hyperscriptHelper, modifierToVNode)
 import OutWatch.Dom.VDomModifier (toProxy)
 import OutWatch.Tags (div, input, strong)
-import Prelude (Unit, bind, pure, (#), ($), (==), (>))
+import Prelude (bind, discard, (#), ($), (==), (>))
 import RxJS.Observable (fromArray)
 import Snabbdom (VDOM)
+import Test.Helper (afterAll, createDomRoot, unsafeFindElement)
 import Test.JsHelpers (stringify)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert (assert, equal)
@@ -50,72 +42,44 @@ outWatchDomSuite =
           json = {"sel":"div","data":{"attrs":{"class":"red","id":"msg"},"on":{},"hook":{}},"children":[{"text":"Hello World!"}]}
       assert "should be equal when encoded to json" ((vtree # stringify) == (stringify json))
     test "The hyperscriptHelper should be able to patch into DOM correctly" do
-      liftEff createDomRoot
+      createDomRoot
       let msg = "HelloWorld!"
           root = hyperscriptHelper "strong" [ text msg ]
       liftEff (render "#app" root)
-      doc <- liftEff getDocument
-      elem <- liftEff (querySelector "strong" (documentToParentNode doc))
+      elem <- unsafeFindElement "strong"
       val <- liftEff (textContent (unsafeCoerce elem))
       assert "Should be equal" $ val == msg
-      liftEff (afterAll)
+      afterAll
     test "The DOM Api should construct correct Vtrees" do
       let vtree = div [className := "red", id := "msg", text "Hello World!"] # modifierToVNode # toProxy
           json = {"sel":"div","data":{"attrs":{"class":"red","id":"msg"},"on":{},"hook":{}},"children":[{"text":"Hello World!"}]}
       assert "should be equal when encoded to json" ((vtree # stringify) == (stringify json))
     test "The DOM Api should be able to patch into DOM correctly" do
-      liftEff createDomRoot
+      createDomRoot
       let msg = "HelloWorld!"
           root = strong [ text msg ]
       liftEff (render "#app" root)
-      doc <- liftEff getDocument
-      elem <- liftEff (querySelector "strong" (documentToParentNode doc))
+      elem <- unsafeFindElement "strong"
       val <- liftEff (textContent (unsafeCoerce elem))
       assert "Should be equal" $ val == msg
-      liftEff (afterAll)
+      afterAll
     test "The DOM Api should be able to set the value of a text field" do
-      liftEff createDomRoot
+      createDomRoot
       let msg = "HelloWorld!"
           root = input [ value := msg ]
       liftEff (render "#app" root)
-      doc <- liftEff getDocument
-      elem <- liftEff (querySelector "input" (documentToParentNode doc))
+      elem <- unsafeFindElement "input"
       val <- liftEff (HTML.value (unsafeCoerce elem))
       assert "Should be equal" $ val == msg
-      liftEff (afterAll)
+      afterAll
     test "The DOM Api should be able to change the value of a text field" do
-      liftEff createDomRoot
+      createDomRoot
       let msg1 = "HelloWorld!"
           msg2 = "Another Message!"
           values = fromArray [ msg1, msg2 ]
           root = input [ value <== values ]
       liftEff (render "#app" root)
-      doc <- liftEff getDocument
-      elem <- liftEff (querySelector "input" (documentToParentNode doc))
+      elem <- unsafeFindElement "input"
       val <- liftEff (HTML.value (unsafeCoerce elem))
       assert "Should be equal" $ val == msg2
-      liftEff (afterAll)
-
-
-getDocument :: forall e. Eff (dom :: DOM | e) Document
-getDocument = do
-  wndow <- window
-  doc <- document wndow
-  pure $ htmlDocumentToDocument doc
-
-createDomRoot :: forall e. Eff (dom :: DOM | e) Node
-createDomRoot = do
-  doc <- getDocument
-  node <- createElement "div" doc
-  bdy <- body $ unsafeCoerce doc
-  child <- appendChild (elementToNode node) (htmlElementToNode (unsafeCoerce bdy))
-  setAttribute "id" "app" (unsafeCoerce child)
-  pure child
-
-afterAll :: forall e. Eff (dom :: DOM | e) Unit
-afterAll = do
-  wndow <- window
-  doc <- document wndow
-  node <- createElement "div" (htmlDocumentToDocument doc)
-  bdy <- body doc
-  setTextContent "" (unsafeCoerce bdy)
+      afterAll

--- a/test/ScenarioTestSpec.purs
+++ b/test/ScenarioTestSpec.purs
@@ -1,30 +1,23 @@
 module Test.ScenarioTestSpec where
 
 import Control.Monad.Aff.AVar (AVAR)
-import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Exception (EXCEPTION)
 import Control.Monad.Eff.Random (RANDOM)
 import DOM (DOM)
 import DOM.Event.EventTarget (dispatchEvent)
-import DOM.HTML (window)
-import DOM.HTML.Document (body)
-import DOM.HTML.Types (htmlDocumentToDocument, htmlElementToNode)
-import DOM.HTML.Window (document)
-import DOM.Node.Document (createElement)
-import DOM.Node.Element (setAttribute)
-import DOM.Node.Node (appendChild, setTextContent, textContent)
-import DOM.Node.ParentNode (querySelector)
-import DOM.Node.Types (Document, Node, documentToParentNode, elementToEventTarget, elementToNode)
+import DOM.Node.Node (textContent)
+import DOM.Node.Types (elementToEventTarget)
 import OutWatch.Attributes (childShow, click, id, (:=), (<==), (==>))
 import OutWatch.Core (render)
 import OutWatch.Dom.EmitterBuilder (mapE)
 import OutWatch.Sink (createHandler)
 import OutWatch.Tags (button, div, span)
-import Prelude (Unit, bind, const, negate, pure, (#), ($), (+), (==))
+import Prelude (bind, const, discard, negate, (#), ($), (+), (==))
 import RxJS.Observable (merge, scan, startWith)
 import Snabbdom (VDOM) as Snabbdom
+import Test.Helper (afterAll, createDomRoot, unsafeFindElement)
 import Test.JsHelpers (newEvent)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert (assert)
@@ -36,7 +29,7 @@ scenarioSuite :: forall e. TestSuite (console :: CONSOLE, testOutput :: TESTOUTP
 scenarioSuite =
   suite "Real Scenario Suite" do
     test "A simple counter application should work correctly" do
-      liftEff createDomRoot
+      createDomRoot
       let plusHandler = createHandler []
           minusHandler = createHandler []
           counters = merge plusHandler.src minusHandler.src
@@ -47,52 +40,28 @@ scenarioSuite =
             , span [ id := "counter", childShow <== counters ]
           ]
       liftEff (render "#app" root)
-      doc <- liftEff getDocument
-      plusElem <- liftEff (querySelector "#plus" (documentToParentNode doc))
-      minusElem <- liftEff (querySelector "#minus" (documentToParentNode doc))
-      counterElem <- liftEff (querySelector "#counter" (documentToParentNode doc))
+      plusElem <-  unsafeFindElement "#plus"
+      minusElem <-  unsafeFindElement "#minus"
+      counterElem <-  unsafeFindElement "#counter"
       let ev = newEvent "click"
           plusTarget = elementToEventTarget $ unsafeCoerce plusElem
           minusTarget = elementToEventTarget $ unsafeCoerce minusElem
       initialCount <- liftEff (textContent $ unsafeCoerce counterElem)
       assert "Should be 0 at the begining" (initialCount == "0")
 
-      liftEff (dispatchEvent ev minusTarget)
+      _ <- liftEff (dispatchEvent ev minusTarget)
 
       afterFirstClick <- liftEff (textContent $ unsafeCoerce counterElem)
       assert "Should be 0 at the begining" (afterFirstClick == "-1")
 
-      liftEff (dispatchEvent ev plusTarget)
+      _ <- liftEff (dispatchEvent ev plusTarget)
 
       afterSecondClick <- liftEff (textContent $ unsafeCoerce counterElem)
       assert "Should be 0 at the begining" (afterSecondClick == "0")
 
-      liftEff (dispatchEvent ev plusTarget)
+      _ <- liftEff (dispatchEvent ev plusTarget)
 
       afterThirdClick <- liftEff (textContent $ unsafeCoerce counterElem)
       assert "Should be 0 at the begining" (afterThirdClick == "1")
 
-      liftEff (afterAll)
-
-getDocument :: forall e. Eff (dom :: DOM | e) Document
-getDocument = do
-  wndow <- window
-  doc <- document wndow
-  pure $ htmlDocumentToDocument doc
-
-createDomRoot :: forall e. Eff (dom :: DOM | e) Node
-createDomRoot = do
-  doc <- getDocument
-  node <- createElement "div" doc
-  bdy <- body $ unsafeCoerce doc
-  child <- appendChild (elementToNode node) (htmlElementToNode (unsafeCoerce bdy))
-  setAttribute "id" "app" (unsafeCoerce child)
-  pure child
-
-afterAll :: forall e. Eff (dom :: DOM | e) Unit
-afterAll = do
-  wndow <- window
-  doc <- document wndow
-  node <- createElement "div" (htmlDocumentToDocument doc)
-  bdy <- body doc
-  setTextContent "" (unsafeCoerce bdy)
+      afterAll


### PR DESCRIPTION
Compiles outwatch with purescript 0.11.
Currently still uses patched versions for purescript-snabbdom and purescript-rxjs, should be replaced with the proper version when they have also moved to 0.11.

Fixes  #11